### PR TITLE
Fix installing error 

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -6,7 +6,7 @@
     "description" : "Email validator for Raku",
     "tags"        : ["Email", "Valid", "Validator"],
     "provides": {
-        "Email::Valid"         : "lib/Email/Valid.pm6"
+        "Email::Valid"         : "lib/Email/Valid.rakumod"
     },
     "depends"     : ["Net::DNS"],
     "auth" : "github:demayl",


### PR DESCRIPTION
`Failed to open file ...\lib\Email\Valid.pm6: No such file or directory`
File extension in provides was `pm6`